### PR TITLE
Set tabs to readOnly & fix console cmdbar

### DIFF
--- a/create/controllers/console.lua
+++ b/create/controllers/console.lua
@@ -107,7 +107,7 @@ consoleController.createConsole = function(workshop)
 		fontSize = 20,
 		textColour = colour(1, 1, 1),
 		name = "cmdInputText"
-	}, "light")
+	}, "secondary")
 
 	closeButton:mouseLeftPressed(function() 
 		consoleController.consoleObject.visible = false

--- a/create/controllers/console.lua
+++ b/create/controllers/console.lua
@@ -138,6 +138,7 @@ consoleController.createConsole = function(workshop)
 					commandHistoryIndex = #commandHistory + 1
 					
 					print("> "..cmdInputText.text)
+					wait()
 					workshop:loadString(cmdInputText.text)
 					
 					cmdInputText.text = ""

--- a/create/controllers/uiTabController.lua
+++ b/create/controllers/uiTabController.lua
@@ -27,7 +27,8 @@ function controller.createTab(container, name, callback)
 	        text = name,
 	        align = enums.align.middle,
 	        hoverCursor = "fa:s-hand-pointer",
-	        fontSize = 18
+			fontSize = 18,
+			readOnly = true
 	    }, active and controller.widgets[container].selected or controller.widgets[container].deselected)
 
 		controller.widgets[container].tabs[btn] = callback


### PR DESCRIPTION
Set the tabs to readOnly, since they could be edited.
Changed the console command bar to use the same colour scheme as the rest of the console