### PR TITLE
Simplify calculateAngleBetween3Points

### DIFF
--- a/create/tools/rotate.lua
+++ b/create/tools/rotate.lua
@@ -65,9 +65,11 @@ local boundingEvent
 -- calculates angle ABC
 -- returns in radians
 local function calculateAngleBetween3Points(a, b, c)
-	local v1 = a - b
-	local v2 = c - b
-	return math.acos(v1:normal():dot(v2:normal()))
+	if not a or not b or not c then
+		return 0 -- Return zero
+	end
+	-- Assuming that a,b,c are non-nil values
+	return math.acos((a-b):normal():dot((c-b):normal()))
 end
 
 local function calculateCircleAngle(hitbox, pos)


### PR DESCRIPTION
Seen as a,b,c were entered in as raw values to begin with, I don't think that declaring operations (a-b) & (c-b) is/are sufficient as variables. Should probably check to see if a,b,c exists before it's being passed in to prevent possible edge cases from happening. 

Probably a good idea to implement error (exits, but provides a message) and warn (pass, but provides a message) methods or something similar to prevent obscure error handling such as this. Whatever works. 