### PR TITLE
Added dragable optional parameter to ui.window

### DIFF
--- a/workshop/controllers/ui/components/topBar.lua
+++ b/workshop/controllers/ui/components/topBar.lua
@@ -26,7 +26,7 @@ local tabs = {
       {"Settings", "fa:s-cog", function ()
         shared.windows.settings.visible = not shared.windows.settings.visible
       end},
-      {"Test", "fa:s-satellite-dish", function ()
+      {"Test", "fa:s-play-circle", function ()
          if not shared.workshop.gameFilePath or shared.workshop.gameFilePath == "" then
             ui.prompt("Please save this game before testing.")
          else

--- a/workshop/controllers/ui/core/ui.lua
+++ b/workshop/controllers/ui/core/ui.lua
@@ -76,7 +76,7 @@ return {
 
     -- if closable is true OR a function, a close button will appear in the title bar.
     -- when clicked, if closable is a function, it is fired after hiding the window.
-    window = function(parent, title, size, position, dockable, closable)
+    window = function(parent, title, size, position, dockable, closable, dragable)
         local container = create("guiFrame", parent, {
             size = size,
             name = title,
@@ -102,6 +102,7 @@ return {
         }, themer.types.primary)
 
         titleBar:mouseLeftPressed(function ()
+            if dragable == false then return end -- Backwards compatibility
             dock.beginWindowDrag(container, not dockable)
         end)
 


### PR DESCRIPTION
This is for windows that don't want to be dragged and instead be locked in one position. It's backward compatible and should work with existing code. 